### PR TITLE
Use 128-bit data loading

### DIFF
--- a/kernels/flash-attn/cutlass/flash_attn_cute.cu
+++ b/kernels/flash-attn/cutlass/flash_attn_cute.cu
@@ -37,7 +37,7 @@ struct FlashAttnConfig {
 
   // Gmem2Smem config
   using GmemCopyAtom =
-      Copy_Atom<AutoVectorizingCopyWithAssumedAlignment<sizeof(uint128_t)>, T>;
+      Copy_Atom<AutoVectorizingCopyWithAssumedAlignment<sizeof(uint128_t)*8>, T>;
   static constexpr int GmemValsPerLoad = sizeof(uint128_t) / sizeof(T);
   static constexpr int GmemThreadsPerRow =
       HeadDim / GmemValsPerLoad; // each thread reads 128 bit
@@ -56,7 +56,7 @@ struct FlashAttnConfig {
   using SmemCopyAtomTransposed =
       Copy_Atom<SM75_U16x8_LDSM_T, T>; // for column major load
   using SmemCopyAtomO =
-      Copy_Atom<AutoVectorizingCopyWithAssumedAlignment<sizeof(uint128_t)>,
+      Copy_Atom<AutoVectorizingCopyWithAssumedAlignment<sizeof(uint128_t)*8>,
                 T>; // NOTE: stmatrix is only available after sm90, we use a
                     // vectorized copy instead
 


### PR DESCRIPTION
For 128-bit vectorized load operations, we should use AutoVectorizingCopyWithAssumedAlignment<sizeof(uint128_t)*8> instead of AutoVectorizingCopyWithAssumedAlignment<sizeof(uint128_t)>. This is because the AutoVectorizingCopyWithAssumedAlignment template parameter expects the alignment value in bits, whereas sizeof(uint128_t) returns 16 bytes. Passing the byte value directly would mistakenly make the template use 16-bit alignment, resulting in actual operations using uint16_t for data loading rather than the intended 128-bit vectorized loading.