### PR TITLE
fix: bracket error in mat_transpose.cu

### DIFF
--- a/kernels/mat-transpose/mat_transpose.cu
+++ b/kernels/mat-transpose/mat_transpose.cu
@@ -364,8 +364,8 @@ __global__ void mat_transpose_f32x4_shared_bcf_merge_write_row2col2d_kernel(
     dim3 block(WARP_SIZE_S, WARP_SIZE_S);                                      \
     dim3 grid((N + WARP_SIZE_S - 1) / (WARP_SIZE_S * n_element_col),           \
               (M + WARP_SIZE_S - 1) / (WARP_SIZE_S * n_element_row));          \
-    mat_transpose_##tag##2d_kernel < < < grid,                                 \
-        block >>> (reinterpret_cast<element_type *>(x.data_ptr()),             \
+    mat_transpose_##tag##2d_kernel<<<grid, block>>>(                           \
+                   reinterpret_cast<element_type *>(x.data_ptr()),             \
                    reinterpret_cast<element_type *>(y.data_ptr()), M, N);      \
   }
 


### PR DESCRIPTION
<<<中间有多余的空格导致编译出错。这个应该是pre-commit的影响，开启pre-commit后会自动添加这些空格