### PR TITLE
fix: add tail-case handling for elementwise_add_f16x8_pack_kernel to …

### DIFF
--- a/kernels/elementwise/elementwise.cu
+++ b/kernels/elementwise/elementwise.cu
@@ -118,7 +118,7 @@ __global__ void elementwise_add_f16x8_pack_kernel(half *a, half *b, half *c,
   if ((idx + 7) < N) {
     LDST128BITS(c[idx]) = LDST128BITS(pack_c[0]);
   } else {
-    for (int i=0; nx+i<N; i++) {
+    for (int i=0; idx+i<N; i++) {
       c[idx+i] = __hadd(a[idx+i], b[idx+i]);
     }
   }

--- a/kernels/elementwise/elementwise.cu
+++ b/kernels/elementwise/elementwise.cu
@@ -119,7 +119,7 @@ __global__ void elementwise_add_f16x8_pack_kernel(half *a, half *b, half *c,
     LDST128BITS(c[idx]) = LDST128BITS(pack_c[0]);
   } else {
     for (int i=0; nx+i<N; i++) {
-      c[nx+i] = __hadd(a[nx+i], b[nx+i]);
+      c[idx+i] = __hadd(a[idx+i], b[idx+i]);
     }
   }
 }

--- a/kernels/elementwise/elementwise.cu
+++ b/kernels/elementwise/elementwise.cu
@@ -117,6 +117,10 @@ __global__ void elementwise_add_f16x8_pack_kernel(half *a, half *b, half *c,
   // reinterpret as float4 and store 128 bits in 1 memory issue.
   if ((idx + 7) < N) {
     LDST128BITS(c[idx]) = LDST128BITS(pack_c[0]);
+  } else {
+    for (int i=0; nx+i<N; i++) {
+      c[nx+i] = __hadd(a[nx+i], b[nx+i]);
+    }
   }
 }
 


### PR DESCRIPTION
# Background
In `elementwise_add_f16x8_pack_kernel`, each thread processes 8 half elements at once. However, when the input length N is not divisible by 8, the last thread may perform out-of-bounds memory access.

# Changes
Added a tail-case handling branch to safely compute the remaining elements one by one:
```c++
} else {
    for (int i = 0; nx + i < N; ++i) {
        d_c[nx + i] = __hadd(d_a[nx + i], d_b[nx + i]);
    }
}
```

# Impact
1. Prevents potential out-of-bounds access when N % 8 != 0.
2. Keeps vectorized performance intact when N is a multiple of 8.