### PR TITLE
misc: Update .gitignore to keep git from user local settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ bin
 __pycache__
 pdfs
 build*
+.vscode
+.idea
+.github/copilot-instructions.md
+AGENTS.md


### PR DESCRIPTION
As the title stated, this PR update `.gitignore` to keep git clean that block the user local settings.

`.github/copilot-instructions.md` and `AGENTS.md` are for helping code agents better work with the user.