### PR TITLE
Change device retrieval method to use torch.device because Triton 3.0…

### DIFF
--- a/kernels/openai-triton/vector-add/triton_vector_add.py
+++ b/kernels/openai-triton/vector-add/triton_vector_add.py
@@ -24,8 +24,7 @@ import torch
 import triton
 import triton.language as tl
 
-DEVICE = triton.runtime.driver.active.get_active_torch_device()
-
+DEVICE = torch.device("cuda:0")
 
 @triton.jit
 def add_kernel(


### PR DESCRIPTION
… API no longer supports the device interface.