### PR TITLE
fix(sgemm): destroy cublas handle to avoid alloc failed

### DIFF
--- a/kernels/sgemm/sgemm_cublas.cu
+++ b/kernels/sgemm/sgemm_cublas.cu
@@ -14,31 +14,43 @@
 
 #include "cublas_v2.h"
 
+#define CHECK_CUBLAS(call)                                                     \
+  do {                                                                         \
+    cublasStatus_t status = (call);                                            \
+    if (status != CUBLAS_STATUS_SUCCESS) {                                     \
+      throw std::runtime_error("cuBLAS call failed");                         \
+    }                                                                          \
+  } while (0)
+
 void cublas_sgemm(float *A, float *B, float *C, size_t M, size_t N, size_t K) {
   cublasHandle_t handle = nullptr;
-  cublasCreate(&handle);
-  cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH);
+  CHECK_CUBLAS(cublasCreate(&handle));
+  CHECK_CUBLAS(cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH));
 
   static float alpha = 1.0;
   static float beta = 0.0;
 
-  cublasGemmEx(handle, CUBLAS_OP_N, CUBLAS_OP_N, N, M, K, &alpha, B, CUDA_R_32F,
-               N, A, CUDA_R_32F, K, &beta, C, CUDA_R_32F, N, CUBLAS_COMPUTE_32F,
-               CUBLAS_GEMM_DEFAULT);
+  CHECK_CUBLAS(cublasGemmEx(handle, CUBLAS_OP_N, CUBLAS_OP_N, N, M, K, &alpha,
+                            B, CUDA_R_32F, N, A, CUDA_R_32F, K, &beta, C,
+                            CUDA_R_32F, N, CUBLAS_COMPUTE_32F,
+                            CUBLAS_GEMM_DEFAULT));
+  CHECK_CUBLAS(cublasDestroy(handle));
 }
 
 void cublas_sgemm_tf32(float *A, float *B, float *C, size_t M, size_t N,
                        size_t K) {
   cublasHandle_t handle = nullptr;
-  cublasCreate(&handle);
-  cublasSetMathMode(handle, CUBLAS_TF32_TENSOR_OP_MATH);
+  CHECK_CUBLAS(cublasCreate(&handle));
+  CHECK_CUBLAS(cublasSetMathMode(handle, CUBLAS_TF32_TENSOR_OP_MATH));
 
   static float alpha = 1.0;
   static float beta = 0.0;
 
-  cublasGemmEx(handle, CUBLAS_OP_N, CUBLAS_OP_N, N, M, K, &alpha, B, CUDA_R_32F,
-               N, A, CUDA_R_32F, K, &beta, C, CUDA_R_32F, N, CUBLAS_COMPUTE_32F,
-               CUBLAS_GEMM_DEFAULT_TENSOR_OP);
+  CHECK_CUBLAS(cublasGemmEx(handle, CUBLAS_OP_N, CUBLAS_OP_N, N, M, K, &alpha,
+                            B, CUDA_R_32F, N, A, CUDA_R_32F, K, &beta, C,
+                            CUDA_R_32F, N, CUBLAS_COMPUTE_32F,
+                            CUBLAS_GEMM_DEFAULT_TENSOR_OP));
+  CHECK_CUBLAS(cublasDestroy(handle));
 }
 
 #define STRINGFY(str) #str


### PR DESCRIPTION
- What
Fix cuBLAS handle leak in kernels/sgemm/sgemm_cublas.cu by destroying handle after GEMM, and add status checks for cuBLAS API calls.

- Why
Repeated benchmark calls can accumulate unreleased cuBLAS handles, then torch.matmul may fail with CUBLAS_STATUS_ALLOC_FAILED when creating a new handle.

- Changes
Added CHECK_CUBLAS macro for cuBLAS status checking
cublas_sgemm: create -> setMathMode -> gemm -> destroy
cublas_sgemm_tf32: create -> setMathMode -> gemm -> destroy

- Repro error
RuntimeError: CUDA error: CUBLAS_STATUS_ALLOC_FAILED when calling cublasCreate(handle)

- Link issue
Fixes #414

- Environment
GPU: NVIDIA H200 NVL (143771 MiB)
Driver: 580.126.09
CUDA Toolkit (nvcc): 12.8 (Build cuda_12.8.r12.8/compiler.35583870_0)
PyTorch: 2.5.0+cu124
PyTorch CUDA runtime: 12.4
CUDA available in torch: True
Compute capability: (9, 0)
