### PR TITLE
fix: correct boundary checks in vectorized elementwise kernels

### DIFF
--- a/kernels/elementwise/elementwise.cu
+++ b/kernels/elementwise/elementwise.cu
@@ -33,7 +33,7 @@ __global__ void elementwise_add_f32_kernel(float *a, float *b, float *c,
 __global__ void elementwise_add_f32x4_kernel(float *a, float *b, float *c,
                                              int N) {
   int idx = 4 * (blockIdx.x * blockDim.x + threadIdx.x);
-  if (idx < N) {
+  if ((idx + 3) < N) {
     float4 reg_a = FLOAT4(a[idx]);
     float4 reg_b = FLOAT4(b[idx]);
     float4 reg_c;
@@ -42,6 +42,10 @@ __global__ void elementwise_add_f32x4_kernel(float *a, float *b, float *c,
     reg_c.z = reg_a.z + reg_b.z;
     reg_c.w = reg_a.w + reg_b.w;
     FLOAT4(c[idx]) = reg_c;
+  } else if (idx < N) {
+    for (int i = 0; (idx + i) < N; i++) {
+      c[idx + i] = a[idx + i] + b[idx + i];
+    }
   }
 }
 
@@ -57,68 +61,68 @@ __global__ void elementwise_add_f16_kernel(half *a, half *b, half *c, int N) {
 // a: Nx1, b: Nx1, c: Nx1, c = elementwise_add(a, b)
 __global__ void elementwise_add_f16x2_kernel(half *a, half *b, half *c, int N) {
   int idx = 2 * (blockIdx.x * blockDim.x + threadIdx.x);
-  if (idx < N) {
+  if ((idx + 1) < N) {
     half2 reg_a = HALF2(a[idx]);
     half2 reg_b = HALF2(b[idx]);
     half2 reg_c;
     reg_c.x = __hadd(reg_a.x, reg_b.x);
     reg_c.y = __hadd(reg_a.y, reg_b.y);
     HALF2(c[idx]) = reg_c;
+  } else if (idx < N) {
+    c[idx] = __hadd(a[idx], b[idx]);
   }
 }
 
 __global__ void elementwise_add_f16x8_kernel(half *a, half *b, half *c, int N) {
   int idx = 8 * (blockIdx.x * blockDim.x + threadIdx.x);
-  half2 reg_a_0 = HALF2(a[idx + 0]);
-  half2 reg_a_1 = HALF2(a[idx + 2]);
-  half2 reg_a_2 = HALF2(a[idx + 4]);
-  half2 reg_a_3 = HALF2(a[idx + 6]);
-  half2 reg_b_0 = HALF2(b[idx + 0]);
-  half2 reg_b_1 = HALF2(b[idx + 2]);
-  half2 reg_b_2 = HALF2(b[idx + 4]);
-  half2 reg_b_3 = HALF2(b[idx + 6]);
-  half2 reg_c_0, reg_c_1, reg_c_2, reg_c_3;
-  reg_c_0.x = __hadd(reg_a_0.x, reg_b_0.x);
-  reg_c_0.y = __hadd(reg_a_0.y, reg_b_0.y);
-  reg_c_1.x = __hadd(reg_a_1.x, reg_b_1.x);
-  reg_c_1.y = __hadd(reg_a_1.y, reg_b_1.y);
-  reg_c_2.x = __hadd(reg_a_2.x, reg_b_2.x);
-  reg_c_2.y = __hadd(reg_a_2.y, reg_b_2.y);
-  reg_c_3.x = __hadd(reg_a_3.x, reg_b_3.x);
-  reg_c_3.y = __hadd(reg_a_3.y, reg_b_3.y);
-  if ((idx + 0) < N) {
+  if ((idx + 7) < N) {
+    half2 reg_a_0 = HALF2(a[idx + 0]);
+    half2 reg_a_1 = HALF2(a[idx + 2]);
+    half2 reg_a_2 = HALF2(a[idx + 4]);
+    half2 reg_a_3 = HALF2(a[idx + 6]);
+    half2 reg_b_0 = HALF2(b[idx + 0]);
+    half2 reg_b_1 = HALF2(b[idx + 2]);
+    half2 reg_b_2 = HALF2(b[idx + 4]);
+    half2 reg_b_3 = HALF2(b[idx + 6]);
+    half2 reg_c_0, reg_c_1, reg_c_2, reg_c_3;
+    reg_c_0.x = __hadd(reg_a_0.x, reg_b_0.x);
+    reg_c_0.y = __hadd(reg_a_0.y, reg_b_0.y);
+    reg_c_1.x = __hadd(reg_a_1.x, reg_b_1.x);
+    reg_c_1.y = __hadd(reg_a_1.y, reg_b_1.y);
+    reg_c_2.x = __hadd(reg_a_2.x, reg_b_2.x);
+    reg_c_2.y = __hadd(reg_a_2.y, reg_b_2.y);
+    reg_c_3.x = __hadd(reg_a_3.x, reg_b_3.x);
+    reg_c_3.y = __hadd(reg_a_3.y, reg_b_3.y);
     HALF2(c[idx + 0]) = reg_c_0;
-  }
-  if ((idx + 2) < N) {
     HALF2(c[idx + 2]) = reg_c_1;
-  }
-  if ((idx + 4) < N) {
     HALF2(c[idx + 4]) = reg_c_2;
-  }
-  if ((idx + 6) < N) {
     HALF2(c[idx + 6]) = reg_c_3;
+  } else if (idx < N) {
+    for (int i = 0; (idx + i) < N; i++) {
+      c[idx + i] = __hadd(a[idx + i], b[idx + i]);
+    }
   }
 }
 
 __global__ void elementwise_add_f16x8_pack_kernel(half *a, half *b, half *c,
                                                   int N) {
   int idx = 8 * (blockIdx.x * blockDim.x + threadIdx.x);
-  // temporary register(memory), .local space in ptx, addressable
-  half pack_a[8], pack_b[8], pack_c[8]; // 8x16 bits=128 bits.
-  // reinterpret as float4 and load 128 bits in 1 memory issue.
-  LDST128BITS(pack_a[0]) = LDST128BITS(a[idx]); // load 128 bits
-  LDST128BITS(pack_b[0]) = LDST128BITS(b[idx]); // load 128 bits
+  if ((idx + 7) < N) {
+    // temporary register(memory), .local space in ptx, addressable
+    half pack_a[8], pack_b[8], pack_c[8]; // 8x16 bits=128 bits.
+    // reinterpret as float4 and load 128 bits in 1 memory issue.
+    LDST128BITS(pack_a[0]) = LDST128BITS(a[idx]); // load 128 bits
+    LDST128BITS(pack_b[0]) = LDST128BITS(b[idx]); // load 128 bits
 
 #pragma unroll
-  for (int i = 0; i < 8; i += 2) {
-    // __hadd2 for half2 x 4
-    HALF2(pack_c[i]) = __hadd2(HALF2(pack_a[i]), HALF2(pack_b[i]));
-  }
-  // reinterpret as float4 and store 128 bits in 1 memory issue.
-  if ((idx + 7) < N) {
+    for (int i = 0; i < 8; i += 2) {
+      // __hadd2 for half2 x 4
+      HALF2(pack_c[i]) = __hadd2(HALF2(pack_a[i]), HALF2(pack_b[i]));
+    }
+    // reinterpret as float4 and store 128 bits in 1 memory issue.
     LDST128BITS(c[idx]) = LDST128BITS(pack_c[0]);
-  } else {
-    for (int i = 0; idx + i < N; i++) {
+  } else if (idx < N) {
+    for (int i = 0; (idx + i) < N; i++) {
       c[idx + i] = __hadd(a[idx + i], b[idx + i]);
     }
   }


### PR DESCRIPTION
- Fix f32x4 kernel: check (idx+3) < N before float4 load
- Fix f16x2 kernel: add tail handling for last element
- Fix f16x8 kernel: move boundary check before data load
- Fix f16x8_pack kernel: prevent out-of-bounds 128-bit load

Prevents potential memory access violations when N is not aligned to vector size.