### PR TITLE
optimize: reuse loaded value in safe_softmax_f32_per_token_kernel

### DIFF
--- a/kernels/softmax/softmax.cu
+++ b/kernels/softmax/softmax.cu
@@ -204,7 +204,7 @@ __global__ void safe_softmax_f32_per_token_kernel(float *x, float *y, int N) {
 
   float val = (idx < N) ? x[idx] : -FLT_MAX;
   float max_val = block_reduce_max_f32<NUM_THREADS>(val); // block max
-  float exp_val = (idx < N) ? expf(x[idx] - max_val) : 0.0f;
+  float exp_val = (idx < N) ? expf(val - max_val) : 0.0f;
   float exp_sum = block_reduce_sum_f32<NUM_THREADS>(exp_val); // block sum
   // e^x_i/sum(e^x_0,...,e^x_n-1)
   if (idx < N)


### PR DESCRIPTION
## Summary

Reuse the already loaded `val` variable in `safe_softmax_f32_per_token_kernel` instead of accessing `x[idx]` again.
The kernel already loads `x[idx]` (or `-FLT_MAX` for inactive threads) into the local variable `val`. The subsequent `expf` call accesses `x[idx]` again.

This change replaces:

```cpp
expf(x[idx] - max_val)
```

with:

```cpp
expf(val - max_val)
```

## Benefits

* Reuses the value already available in the local variable.
* Avoids repeated indexing of `x[idx]`.
* Improves readability and consistency with the FP16 softmax implementation.
* May allow the compiler to reuse the existing register value.
