### PR TITLE
fix: correct tail buffer selection in double-buffered SGEMM

### DIFF
--- a/kernels/sgemm/sgemm.cu
+++ b/kernels/sgemm/sgemm.cu
@@ -461,12 +461,16 @@ __global__ void sgemm_t_8x8_sliced_k_f32x4_bcf_dbuf_kernel(
   }
 
 // 计算剩下最后一块BK
+  // Which buffer holds the final tile depends on parity of the loop's
++ // last iteration (bk = numTiles - 1), matching smem_sel_next's formula.
+  int smem_sel_last = ((K + BK - 1) / BK - 1) & 1;
+
 #pragma unroll
   for (int tk = 0; tk < BK; tk++) {
-    FLOAT4(r_comp_a[0]) = FLOAT4(s_a[1][tk][ty * TM / 2]);
-    FLOAT4(r_comp_a[4]) = FLOAT4(s_a[1][tk][ty * TM / 2 + BM / 2]);
-    FLOAT4(r_comp_b[0]) = FLOAT4(s_b[1][tk][tx * TN / 2]);
-    FLOAT4(r_comp_b[4]) = FLOAT4(s_b[1][tk][tx * TN / 2 + BN / 2]);
+    FLOAT4(r_comp_a[0]) = FLOAT4(s_a[smem_sel_last][tk][ty * TM / 2]);
+    FLOAT4(r_comp_a[4]) = FLOAT4(s_a[smem_sel_last][tk][ty * TM / 2 + BM / 2]);
+    FLOAT4(r_comp_b[0]) = FLOAT4(s_b[smem_sel_last][tk][tx * TN / 2]);
+    FLOAT4(r_comp_b[4]) = FLOAT4(s_b[smem_sel_last][tk][tx * TN / 2 + BN / 2]);
 
 #pragma unroll
     for (int tm = 0; tm < TM; tm++) {


### PR DESCRIPTION
# Summary

Fix incorrect shared-memory buffer selection in the tail compute pass of the double-buffered SGEMM kernel.

## Problem

The tail pass always reads from shared-memory buffer `1`, but the final K-tile is written to buffer `(numTiles - 1) & 1`. This is only guaranteed to be buffer `1` when `numTiles` is even. For odd `numTiles`, the tail pass reads stale data from the wrong buffer, producing incorrect results.

## Fix

Compute the final buffer index once:
```c
int smem_sel_last = (((K + BK - 1) / BK) - 1) & 1;
```
and use it instead of the hardcoded buffer index in the tail compute loop.

## Testing

- Verified no regression for existing benchmark shapes (K = 2048, 4096, 8192).
- Verified correctness against torch.matmul for K = 2040 (numTiles = 255), where the previous implementation produced incorrect results.